### PR TITLE
Implement unlisten

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## Changed
-- Removed `injectIntl` from example
+### Added
 
-- **Component** Create the VTEX Store Component _IO Base App_
+- Initial version of OrderManager

--- a/README.md
+++ b/README.md
@@ -2,6 +2,23 @@
 
 > Centralizes the requests queue to the Checkout API.
 
+## Usage
+
+```tsx
+import { OrderManagerProvider, useOrderManager } from 'vtex.order-manager/OrderManager'
+
+const MainComponent: FunctionComponent = () => (
+  <OrderManagerProvider>
+    <MyComponent />
+  </OrderManagerProvider>
+)
+
+const MyComponent: FunctionComponent = () => {
+  const { enqueue, listen } = useOrderManager()
+  //...
+}
+```
+
 ## API
 
 ### `enqueue(task: () => Promise, id?: string): Promise`

--- a/react/OrderManager.tsx
+++ b/react/OrderManager.tsx
@@ -1,4 +1,10 @@
-import React, { createContext, ReactNode, useContext, useState, useMemo } from 'react'
+import React, {
+  createContext,
+  ReactNode,
+  useContext,
+  useState,
+  useMemo,
+} from 'react'
 import { QueueEvent, TaskQueue } from './modules/TaskQueue'
 
 interface Context {
@@ -16,10 +22,13 @@ export const OrderManagerProvider = ({
   children,
 }: OrderManagerProviderProps) => {
   const [queue] = useState(() => new TaskQueue())
-  const value = useMemo(() => ({
-    enqueue: queue.enqueue.bind(queue),
-    listen: queue.listen.bind(queue),
-  }), [queue])
+  const value = useMemo(
+    () => ({
+      enqueue: queue.enqueue.bind(queue),
+      listen: queue.listen.bind(queue),
+    }),
+    [queue]
+  )
 
   return (
     <OrderManagerContext.Provider value={value}>

--- a/react/OrderManager.tsx
+++ b/react/OrderManager.tsx
@@ -9,7 +9,7 @@ import { QueueEvent, TaskQueue } from './modules/TaskQueue'
 
 interface Context {
   enqueue: (task: () => Promise<any>, id?: string) => PromiseLike<void>
-  listen: (event: QueueEvent, callback: () => any) => void
+  listen: (event: QueueEvent, callback: () => any) => () => void
 }
 
 interface OrderManagerProviderProps {

--- a/react/__tests__/OrderManager.test.tsx
+++ b/react/__tests__/OrderManager.test.tsx
@@ -3,9 +3,10 @@ import { render } from '@vtex/test-tools/react'
 
 import { OrderManagerProvider, useOrderManager } from '../OrderManager'
 
-const createScheduledTask = (task: () => any, time: number) => () => new Promise(resolve => {
-  setTimeout(() => resolve(task()), time)
-})
+const createScheduledTask = (task: () => any, time: number) => () =>
+  new Promise(resolve => {
+    setTimeout(() => resolve(task()), time)
+  })
 
 describe('OrderManager', () => {
   it('should throw when useOrderManager is called outside a OrderManagerProvider', () => {
@@ -18,7 +19,9 @@ describe('OrderManager', () => {
       return <div>foo</div>
     }
 
-    expect(() => render(<Component />)).toThrow('useOrderManager must be used within a OrderManagerProvider')
+    expect(() => render(<Component />)).toThrow(
+      'useOrderManager must be used within a OrderManagerProvider'
+    )
 
     console.error = oldConsoleError
   })

--- a/react/__tests__/OrderManager.test.tsx
+++ b/react/__tests__/OrderManager.test.tsx
@@ -14,7 +14,6 @@ describe('OrderManager', () => {
     console.error = () => {}
 
     const Component: FunctionComponent = () => {
-      console.error = () => {}
       useOrderManager()
       return <div>foo</div>
     }

--- a/react/modules/TaskQueue.test.ts
+++ b/react/modules/TaskQueue.test.ts
@@ -92,4 +92,34 @@ describe('TaskQueue', () => {
     queue.enqueue(createScheduledTask(() => {}, 5))
     expect(mockPendingCb.mock.calls.length).toBe(2)
   })
+
+  it('should not call listener callback after unlisten is called', async () => {
+    const queue = new TaskQueue()
+    const mockPendingCb = jest.fn()
+    const unlisten = queue.listen('Pending', mockPendingCb)
+
+    const task = queue.enqueue(async () => {})
+    expect(mockPendingCb.mock.calls.length).toBe(1)
+    await task
+
+    unlisten()
+    queue.enqueue(async () => {})
+    expect(mockPendingCb.mock.calls.length).toBe(1)
+  })
+
+  it('should remove a single listener callback when unlisten is called', async () => {
+    const queue = new TaskQueue()
+    const mockPendingCb = jest.fn()
+    queue.listen('Pending', mockPendingCb)
+    const unlisten = queue.listen('Pending', mockPendingCb)
+    queue.listen('Pending', mockPendingCb)
+
+    const task = queue.enqueue(async () => {})
+    expect(mockPendingCb.mock.calls.length).toBe(3)
+    await task
+
+    unlisten()
+    queue.enqueue(async () => {})
+    expect(mockPendingCb.mock.calls.length).toBe(5)
+  })
 })

--- a/react/modules/TaskQueue.test.ts
+++ b/react/modules/TaskQueue.test.ts
@@ -1,8 +1,9 @@
 import { TaskQueue, TASK_CANCELLED_MSG } from './TaskQueue'
 
-const createScheduledTask = (task: () => any, time: number) => () => new Promise(resolve => {
-  setTimeout(() => resolve(task()), time)
-})
+const createScheduledTask = (task: () => any, time: number) => () =>
+  new Promise(resolve => {
+    setTimeout(() => resolve(task()), time)
+  })
 
 describe('TaskQueue', () => {
   it('should execute a task', async () => {
@@ -19,7 +20,7 @@ describe('TaskQueue', () => {
     await Promise.all([
       queue.enqueue(createScheduledTask(() => results.push('1'), 20)),
       queue.enqueue(createScheduledTask(() => results.push('2'), 10)),
-      queue.enqueue(async () => results.push('3'))
+      queue.enqueue(async () => results.push('3')),
     ])
 
     expect(results).toEqual(['1', '2', '3'])
@@ -29,10 +30,22 @@ describe('TaskQueue', () => {
     const queue = new TaskQueue()
     const results: string[] = []
 
-    const task1 = queue.enqueue(createScheduledTask(() => results.push('1'), 20), 'foo')
-    const task2 = queue.enqueue(createScheduledTask(() => results.push('2'), 5), 'bar')
-    const task3 = queue.enqueue(createScheduledTask(() => results.push('3'), 5), 'baz')
-    const task4 = queue.enqueue(createScheduledTask(() => results.push('4'), 5), 'bar')
+    const task1 = queue.enqueue(
+      createScheduledTask(() => results.push('1'), 20),
+      'foo'
+    )
+    const task2 = queue.enqueue(
+      createScheduledTask(() => results.push('2'), 5),
+      'bar'
+    )
+    const task3 = queue.enqueue(
+      createScheduledTask(() => results.push('3'), 5),
+      'baz'
+    )
+    const task4 = queue.enqueue(
+      createScheduledTask(() => results.push('4'), 5),
+      'bar'
+    )
 
     expect(task2).rejects.toEqual(TASK_CANCELLED_MSG)
 

--- a/react/modules/TaskQueue.test.ts
+++ b/react/modules/TaskQueue.test.ts
@@ -63,13 +63,13 @@ describe('TaskQueue', () => {
     const task2 = queue.enqueue(createScheduledTask(() => {}, 5))
     const task3 = queue.enqueue(createScheduledTask(() => {}, 5))
 
-    expect(mockFulfilledCb.mock.calls.length).toBe(0)
+    expect(mockFulfilledCb).toHaveBeenCalledTimes(0)
     await task1
-    expect(mockFulfilledCb.mock.calls.length).toBe(0)
+    expect(mockFulfilledCb).toHaveBeenCalledTimes(0)
     await task2
-    expect(mockFulfilledCb.mock.calls.length).toBe(0)
+    expect(mockFulfilledCb).toHaveBeenCalledTimes(0)
     await task3
-    expect(mockFulfilledCb.mock.calls.length).toBe(1)
+    expect(mockFulfilledCb).toHaveBeenCalledTimes(1)
   })
 
   it('should emit a Pending event only when the queue is free and receives a task', async () => {
@@ -77,20 +77,20 @@ describe('TaskQueue', () => {
     const mockPendingCb = jest.fn()
     queue.listen('Pending', mockPendingCb)
 
-    expect(mockPendingCb.mock.calls.length).toBe(0)
+    expect(mockPendingCb).toHaveBeenCalledTimes(0)
     const task1 = queue.enqueue(createScheduledTask(() => {}, 5))
-    expect(mockPendingCb.mock.calls.length).toBe(1)
+    expect(mockPendingCb).toHaveBeenCalledTimes(1)
     const task2 = queue.enqueue(createScheduledTask(() => {}, 5))
     const task3 = queue.enqueue(createScheduledTask(() => {}, 5))
-    expect(mockPendingCb.mock.calls.length).toBe(1)
+    expect(mockPendingCb).toHaveBeenCalledTimes(1)
 
     await Promise.all([task1, task2, task3])
 
-    expect(mockPendingCb.mock.calls.length).toBe(1)
+    expect(mockPendingCb).toHaveBeenCalledTimes(1)
     queue.enqueue(createScheduledTask(() => {}, 5))
-    expect(mockPendingCb.mock.calls.length).toBe(2)
+    expect(mockPendingCb).toHaveBeenCalledTimes(2)
     queue.enqueue(createScheduledTask(() => {}, 5))
-    expect(mockPendingCb.mock.calls.length).toBe(2)
+    expect(mockPendingCb).toHaveBeenCalledTimes(2)
   })
 
   it('should not call listener callback after unlisten is called', async () => {
@@ -99,12 +99,12 @@ describe('TaskQueue', () => {
     const unlisten = queue.listen('Pending', mockPendingCb)
 
     const task = queue.enqueue(async () => {})
-    expect(mockPendingCb.mock.calls.length).toBe(1)
+    expect(mockPendingCb).toHaveBeenCalledTimes(1)
     await task
 
     unlisten()
     queue.enqueue(async () => {})
-    expect(mockPendingCb.mock.calls.length).toBe(1)
+    expect(mockPendingCb).toHaveBeenCalledTimes(1)
   })
 
   it('should remove a single listener callback when unlisten is called', async () => {
@@ -115,11 +115,11 @@ describe('TaskQueue', () => {
     queue.listen('Pending', mockPendingCb)
 
     const task = queue.enqueue(async () => {})
-    expect(mockPendingCb.mock.calls.length).toBe(3)
+    expect(mockPendingCb).toHaveBeenCalledTimes(3)
     await task
 
     unlisten()
     queue.enqueue(async () => {})
-    expect(mockPendingCb.mock.calls.length).toBe(5)
+    expect(mockPendingCb).toHaveBeenCalledTimes(5)
   })
 })

--- a/react/modules/TaskQueue.ts
+++ b/react/modules/TaskQueue.ts
@@ -1,6 +1,10 @@
-import { CancellablePromiseLike, SequentialTaskQueue } from 'sequential-task-queue'
+import {
+  CancellablePromiseLike,
+  SequentialTaskQueue,
+} from 'sequential-task-queue'
 
-export const TASK_CANCELLED_MSG = 'A more recent task with same id has been pushed to the queue.'
+export const TASK_CANCELLED_MSG =
+  'A more recent task with same id has been pushed to the queue.'
 
 export type QueueEvent = 'Pending' | 'Fulfilled'
 
@@ -15,7 +19,7 @@ export class TaskQueue {
   private listeners: Record<QueueEvent, (() => any)[]>
   private isEmpty: boolean
 
-  constructor() {
+  public constructor() {
     this.queue = new SequentialTaskQueue()
     this.taskIdMap = {}
     this.listeners = {} as any
@@ -27,9 +31,9 @@ export class TaskQueue {
     })
   }
 
-  enqueue(task: () => Promise<any>, id?: string) {
+  public enqueue(task: () => Promise<any>, id?: string) {
     if (this.isEmpty) {
-      this.isEmpty = false;
+      this.isEmpty = false
       this.emit('Pending')
     }
 
@@ -49,7 +53,7 @@ export class TaskQueue {
     return promise
   }
 
-  listen(event: QueueEvent, cb: () => any) {
+  public listen(event: QueueEvent, cb: () => any) {
     if (!this.listeners[event]) {
       this.listeners[event] = []
     }

--- a/react/modules/TaskQueue.ts
+++ b/react/modules/TaskQueue.ts
@@ -59,6 +59,15 @@ export class TaskQueue {
     }
 
     this.listeners[event].push(cb)
+
+    const unlisten = () => {
+      const index = this.listeners[event].indexOf(cb)
+      if (index !== -1) {
+        this.listeners[event].splice(index, 1)
+      }
+    }
+
+    return unlisten
   }
 
   private emit(event: QueueEvent) {


### PR DESCRIPTION
This implements the `unlisten` function which is returned by the `listen` method as described in the API. This also includes a couple of tests that cover this functionality, fixes some lint errors and updates `README.md` to include a section on how to use this module.