### PR TITLE
Change the way exports are made

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- `OrderManagerProvider` and `useOrderManager` are now `export default`'ed from `OrderManager.tsx`.
+
 ## [0.1.0] - 2019-08-19
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -5,8 +5,7 @@
 ## Usage
 
 ```tsx
-import { OrderManager } from 'vtex.order-manager'
-const { OrderManagerProvider, useOrderManager } = OrderManager
+import { OrderManagerProvider, useOrderManager } from 'vtex.order-manager/OrderManager'
 
 const MainComponent: FunctionComponent = () => (
   <OrderManagerProvider>

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@
 ## Usage
 
 ```tsx
-import { OrderManagerProvider, useOrderManager } from 'vtex.order-manager/OrderManager'
+import { OrderManager } from 'vtex.order-manager'
+const { OrderManagerProvider, useOrderManager } = OrderManager
 
 const MainComponent: FunctionComponent = () => (
   <OrderManagerProvider>

--- a/react/OrderManager.tsx
+++ b/react/OrderManager.tsx
@@ -18,7 +18,7 @@ interface OrderManagerProviderProps {
 
 const OrderManagerContext = createContext<Context | undefined>(undefined)
 
-export const OrderManagerProvider = ({
+const OrderManagerProvider = ({
   children,
 }: OrderManagerProviderProps) => {
   const [queue] = useState(() => new TaskQueue())
@@ -37,7 +37,7 @@ export const OrderManagerProvider = ({
   )
 }
 
-export const useOrderManager = () => {
+const useOrderManager = () => {
   const context = useContext(OrderManagerContext)
   if (context === undefined) {
     throw new Error(
@@ -47,3 +47,5 @@ export const useOrderManager = () => {
 
   return context
 }
+
+export default { OrderManagerProvider, useOrderManager }


### PR DESCRIPTION
~Apparently doing `import { foo, bar } from 'vtex.some-app/SomeFile'` does not work in IO (the consuming app gets `undefined` for each imported element). This PR changes the way `order-manager` does its exports so they can be used by other apps.~
`OrderManager` was not using `export default` to expose its functions, so other apps were not being able to import them. This PR fixes this. This doesn't change the way this module is used.