### PR TITLE
Fix tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed tests that were broken in v0.1.1.
+
 ## [0.1.1] - 2019-08-20
 
 ### Changed

--- a/react/OrderManager.tsx
+++ b/react/OrderManager.tsx
@@ -18,7 +18,7 @@ interface OrderManagerProviderProps {
 
 const OrderManagerContext = createContext<Context | undefined>(undefined)
 
-const OrderManagerProvider = ({
+export const OrderManagerProvider = ({
   children,
 }: OrderManagerProviderProps) => {
   const [queue] = useState(() => new TaskQueue())
@@ -37,7 +37,7 @@ const OrderManagerProvider = ({
   )
 }
 
-const useOrderManager = () => {
+export const useOrderManager = () => {
   const context = useContext(OrderManagerContext)
   if (context === undefined) {
     throw new Error(


### PR DESCRIPTION
Tests were broken because the functions they used were not being exported anymore, only `default export`ed.

This PR simply exports those functions once again and ensures `yarn test` passes all tests.