### PR TITLE
Add code to task cancelled message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- When a task is cancelled, the rejected promise now returns an object with error code and message.
+
 ## [0.1.2] - 2019-08-21
 
 ### Fixed

--- a/react/modules/TaskQueue.test.ts
+++ b/react/modules/TaskQueue.test.ts
@@ -1,4 +1,4 @@
-import { TaskQueue, TASK_CANCELLED_MSG } from './TaskQueue'
+import { TaskQueue, TASK_CANCELLED_CODE, TASK_CANCELLED_MSG } from './TaskQueue'
 
 const createScheduledTask = (task: () => any, time: number) => () =>
   new Promise(resolve => {
@@ -47,7 +47,10 @@ describe('TaskQueue', () => {
       'bar'
     )
 
-    expect(task2).rejects.toEqual(TASK_CANCELLED_MSG)
+    expect(task2).rejects.toEqual({
+      code: TASK_CANCELLED_CODE,
+      message: TASK_CANCELLED_MSG,
+    })
 
     await Promise.all([task1, task3, task4])
 

--- a/react/modules/TaskQueue.ts
+++ b/react/modules/TaskQueue.ts
@@ -3,6 +3,7 @@ import {
   SequentialTaskQueue,
 } from 'sequential-task-queue'
 
+export const TASK_CANCELLED_CODE = 'TASK_CANCELLED'
 export const TASK_CANCELLED_MSG =
   'A more recent task with same id has been pushed to the queue.'
 
@@ -38,7 +39,10 @@ export class TaskQueue {
     }
 
     if (id && this.taskIdMap[id]) {
-      this.taskIdMap[id].promise.cancel(TASK_CANCELLED_MSG)
+      this.taskIdMap[id].promise.cancel({
+        code: TASK_CANCELLED_CODE,
+        message: TASK_CANCELLED_MSG,
+      })
     }
 
     const promise = this.queue.push(task)


### PR DESCRIPTION
This adds an error code to the promise rejection message when a task gets cancelled due to another one with the same ID being pushed to the queue. This makes it easier to treat this promise rejection on the consumer side.