### PR TITLE
Don't cancel a running task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- A running task is not cancelled anymore when another task with same `id` is pushed to the queue.
+
 ## [0.3.1] - 2019-09-05
 
 ### Changed

--- a/react/__mocks__/vtex.checkout-resources/Queries.ts
+++ b/react/__mocks__/vtex.checkout-resources/Queries.ts
@@ -1,9 +1,9 @@
 import gql from 'graphql-tag'
 
 export const orderForm = gql`
-query MockQuery {
-  orderForm {
-    items
+  query MockQuery {
+    orderForm {
+      items
+    }
   }
-}
 `

--- a/react/__tests__/OrderForm.test.tsx
+++ b/react/__tests__/OrderForm.test.tsx
@@ -91,7 +91,7 @@ describe('OrderForm', () => {
 
     const Component: FunctionComponent = () => {
       const { loading, orderForm, setOrderForm } = useOrderForm()
-      if (loading || ! orderForm) {
+      if (loading || !orderForm) {
         return <div>Loading</div>
       }
       const handleClick = () => {

--- a/react/modules/TaskQueue.ts
+++ b/react/modules/TaskQueue.ts
@@ -45,7 +45,14 @@ export class TaskQueue {
       })
     }
 
-    const promise = this.queue.push(task)
+    const wrappedTask = () => {
+      if (id) {
+        delete this.taskIdMap[id]
+      }
+      return task()
+    }
+
+    const promise = this.queue.push(wrappedTask)
 
     if (id) {
       this.taskIdMap[id] = {

--- a/react/modules/TaskQueue.ts
+++ b/react/modules/TaskQueue.ts
@@ -46,7 +46,7 @@ export class TaskQueue {
     }
 
     const wrappedTask = () => {
-      if (id) {
+      if (id && this.taskIdMap[id]) {
         delete this.taskIdMap[id]
       }
       return task()


### PR DESCRIPTION
#### What problem is this solving?

In the current implementation, when a task with some id is _**running**_ and another task with the same id is pushed to the queue, the promise of the first task is rejected and the second task starts running immediately. However, the first task doesn't get effectively cancelled, thus we end up having two tasks running simultaneously, which can be problematic.

This PR prevents this scenario by not cancelling tasks that are running.

#### How should this be manually tested?

`yarn test`

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [x] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
