### PR TITLE
Implement useQueueStatus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `useQueueStatus` hook and `QueueStatus` enum to `OrderQueue`.
+
 ## [0.3.3] - 2019-09-10
+
+### Changed
+
+- Moved `README.md` location to comply with IO Docs Builder requirements.
 
 ## [0.3.2] - 2019-09-10
 

--- a/react/__tests__/OrderQueue.test.tsx
+++ b/react/__tests__/OrderQueue.test.tsx
@@ -1,7 +1,12 @@
 import React, { FunctionComponent, useEffect } from 'react'
-import { render } from '@vtex/test-tools/react'
+import { act, fireEvent, render } from '@vtex/test-tools/react'
 
-import { OrderQueueProvider, useOrderQueue } from '../OrderQueue'
+import { QueueStatus } from '../constants'
+import {
+  OrderQueueProvider,
+  useOrderQueue,
+  useQueueStatus,
+} from '../OrderQueue'
 
 const createScheduledTask = (task: () => any, time: number) => () =>
   new Promise(resolve => {
@@ -35,7 +40,7 @@ describe('OrderQueue', () => {
         tasks.push(enqueue(createScheduledTask(() => results.push('1'), 10)))
         tasks.push(enqueue(createScheduledTask(() => results.push('2'), 5)))
         tasks.push(enqueue(createScheduledTask(() => results.push('3'), 5)))
-      }, [])
+      }, [enqueue])
       return <div>foo</div>
     }
 
@@ -49,5 +54,39 @@ describe('OrderQueue', () => {
 
     await Promise.all(tasks)
     expect(results).toEqual(['1', '2', '3'])
+  })
+
+  it('should keep the ref returned by useQueueStatus updated', async () => {
+    let queueStatusRef: any = null
+    let task = null
+
+    const Component: FunctionComponent = () => {
+      const { enqueue, listen } = useOrderQueue()
+      queueStatusRef = useQueueStatus(listen)
+
+      const handleClick = () => {
+        task = enqueue(createScheduledTask(() => {}, 10))
+      }
+
+      return <button onClick={handleClick}>enqueue</button>
+    }
+
+    const { getByText } = render(
+      <OrderQueueProvider>
+        <Component />
+      </OrderQueueProvider>
+    )
+
+    expect(queueStatusRef).toBeDefined()
+    expect(queueStatusRef.current).toEqual(QueueStatus.FULFILLED)
+
+    const button = getByText('enqueue')
+    act(() => {
+      fireEvent.click(button)
+    })
+    expect(queueStatusRef.current).toEqual(QueueStatus.PENDING)
+
+    await task
+    expect(queueStatusRef.current).toEqual(QueueStatus.FULFILLED)
   })
 })

--- a/react/constants.ts
+++ b/react/constants.ts
@@ -1,0 +1,4 @@
+export enum QueueStatus {
+  PENDING = 'Pending',
+  FULFILLED = 'Fulfilled',
+}


### PR DESCRIPTION
#### What problem is this solving?

Both `OrderItems` and `OrderShipping` want to perform actions conditioned on the status of the queue. In order to do that, they implemented a `ref` object controlled by the events emitted by the queue. This PR moves this logic to `OrderQueue` to avoid this copy-pasta.

In short, this adds a new helper hook `useQueueStatus` that receives the `listen` function returned by `useOrderQueue()` and returns a `ref` object containing the status of the queue (either `Pending` or `Fulfilled`).

#### How should this be manually tested?

`yarn test`
[This workspace](http://orderstatus--vtexgame1.myvtex.com/cart) can also be used for testing. I've linked to it a [modified `OrderItems`](https://github.com/vtex-apps/order-items/tree/chore/queue-status) that uses this new hook.

#### Checklist/Reminders

- [x] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [x] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
