### PR TITLE
Add dummyOrderForm object in order to display product-list skeleton

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `dummyOrderForm` file in order to display `product-list` preview skeleton.
+
 ## [0.4.0] - 2019-10-04
 
 ### Added

--- a/react/OrderForm.tsx
+++ b/react/OrderForm.tsx
@@ -11,6 +11,8 @@ import { compose, graphql } from 'react-apollo'
 
 import { orderForm as OrderFormQuery } from 'vtex.checkout-resources/Queries'
 
+import { dummyOrderForm } from './utils/dummyOrderForm'
+
 interface Context {
   loading: boolean
   orderForm: OrderForm | undefined
@@ -28,7 +30,7 @@ const LoadingState: FunctionComponent = ({ children }: any) => {
   const value = useMemo(
     () => ({
       loading: true,
-      orderForm: undefined,
+      orderForm: dummyOrderForm,
       setOrderForm: () => {},
     }),
     []

--- a/react/utils/dummyOrderForm.ts
+++ b/react/utils/dummyOrderForm.ts
@@ -1,0 +1,50 @@
+const dummyItem = {
+  additionalInfo: {
+    brandName: '',
+  },
+  id: '',
+  detailUrl: '',
+  imageUrl: '',
+  listPrice: 0,
+  measurementUnit: '',
+  name: '',
+  price: 0,
+  productId: '',
+  quantity: 0,
+  sellingPrice: 0,
+  skuName: '',
+  skuSpecifications: [],
+  availability: 'available',
+}
+
+export const dummyOrderForm = {
+  items: [dummyItem, dummyItem],
+  shipping: {
+    countries: [],
+    deliveryOptions: [
+      { id: '', price: 0, estimate: '', isSelected: false },
+      { id: '', price: 0, estimate: '', isSelected: false },
+      { id: '', price: 0, estimate: '', isSelected: false },
+    ],
+    selectedAddress: {
+      addressId: '',
+      addressType: '',
+      city: '',
+      complement: '',
+      country: '',
+      neighborhood: '',
+      number: '',
+      postalCode: '',
+      receiverName: '',
+      reference: '',
+      state: '',
+      street: '',
+      geoCoordinates: [],
+    },
+  },
+  marketingData: {
+    coupon: '',
+  },
+  totalizers: [{ id: '', value: 0, name: '' }],
+  value: 0,
+}


### PR DESCRIPTION
#### What problem is this solving?

This PR adds a dummy order-form object to `LoadingState` in order to display `product-list`'s preview skeleton.

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

- Go to [Workspace](https://productskeleton--checkoutio.myvtex.com/cart)
- Verify that it's displaying a skeleton.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] [Linked this PR to a Clubhouse story (if applicable).](https://app.clubhouse.io/vtex/story/24408/aplicar-o-skeleton-no-carregamento-do-carrinho)
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/12574426/67779778-e4ce7800-fa43-11e9-8015-dd8ca6cb8865.png)


#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

