### PR TITLE
Update loading state on OrderFormProvider and prevent SSR query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- `loading` attribute would not be updated on `OrderFormContext`.
+- `orderForm` query being executed during SSR.
+
 ## [0.6.1] - 2019-11-12
 
 ### Fixed

--- a/react/OrderForm.tsx
+++ b/react/OrderForm.tsx
@@ -21,7 +21,9 @@ interface Context {
 const OrderFormContext = createContext<Context | undefined>(undefined)
 
 export const OrderFormProvider: FC = ({ children }) => {
-  const { loading, data } = useQuery<{ orderForm: OrderForm }>(OrderFormQuery)
+  const { loading, data } = useQuery<{ orderForm: OrderForm }>(OrderFormQuery, {
+    ssr: false,
+  })
 
   const [orderForm, setOrderForm] = useReducer(
     (orderForm: OrderForm, newOrderForm: Partial<OrderForm>) => ({
@@ -40,11 +42,11 @@ export const OrderFormProvider: FC = ({ children }) => {
 
   const value = useMemo(
     () => ({
-      loading: false,
+      loading,
       orderForm,
       setOrderForm,
     }),
-    [orderForm]
+    [loading, orderForm]
   )
 
   return (


### PR DESCRIPTION
#### What problem is this solving?

The `loading` state would not be updated on OrderFormContext and prevent `orderForm` query was being executed during SSR.

#### How should this be manually tested?

[Workspace](https://minicart--storecomponents.myvtex.com/)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->
