### PR TITLE
Log error when orderForm query fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `error` property returned by the order form GraphQL query to the `OrderFormContext`.
+- Log to Splunk when the order form query fails.
+
 ## [0.6.5] - 2019-12-09
 
 ### Fixed

--- a/docs/README.md
+++ b/docs/README.md
@@ -141,10 +141,16 @@ This flag is set to `true` only when `OrderManager` is loading the order form du
 
 > Returned by `useOrderForm()`
 
-Contains data from the order form. Do not modify this directly, use `setOrderForm` instead.
+Contains data from the order form. Do not modify this directly, use `setOrderForm` instead. In case the order form query fails, an empty order form is returned instead (see [`error`](#error-apolloerror--undefined)).
 
 ### `setOrderForm: (newOrderForm: Partial<OrderForm>) => void`
 
 > Returned by `useOrderForm()`
 
 Updates the order form stored in `OrderManager`. This should be called after each mutation to ensure that client data does not get out of sync with server data and that other `OrderManager` consumers can react to this update.
+
+### `error: ApolloError | undefined`
+
+> Returned by `useOrderForm()`
+
+A reference to the `error` object returned by the GraphQL query for the order form.

--- a/react/package.json
+++ b/react/package.json
@@ -5,6 +5,7 @@
   },
   "dependencies": {
     "@vtex/css-handles": "^1.0.0",
+    "axios": "^0.19.0",
     "classnames": "^2.2.6",
     "ramda": "^0.26.1",
     "react": "^16.8.3",
@@ -12,6 +13,7 @@
     "react-dom": "^16.8.3",
     "react-intl": "^2.7.2",
     "recompose": "^0.30.0",
+    "splunk-events": "^1.3.0",
     "yarn": "^1.17.3"
   },
   "devDependencies": {

--- a/react/typings/splunk-events.d.ts
+++ b/react/typings/splunk-events.d.ts
@@ -1,0 +1,7 @@
+declare module 'splunk-events' {
+  interface Constructable<T> {
+    new (): T
+  }
+  const Splunk: Constructable<any>
+  export default Splunk
+}

--- a/react/utils/dummyOrderForm.ts
+++ b/react/utils/dummyOrderForm.ts
@@ -48,3 +48,31 @@ export const dummyOrderForm = {
   totalizers: [{ id: '', value: 0, name: '' }],
   value: 0,
 }
+
+export const emptyOrderForm = {
+  items: [],
+  shipping: {
+    countries: [],
+    deliveryOptions: [],
+    selectedAddress: {
+      addressId: '',
+      addressType: '',
+      city: '',
+      complement: '',
+      country: '',
+      neighborhood: '',
+      number: '',
+      postalCode: '',
+      receiverName: '',
+      reference: '',
+      state: '',
+      street: '',
+      geoCoordinates: [],
+    },
+  },
+  marketingData: {
+    coupon: '',
+  },
+  totalizers: [{ id: '', value: 0, name: '' }],
+  value: 0,
+}

--- a/react/utils/logger.ts
+++ b/react/utils/logger.ts
@@ -1,0 +1,45 @@
+import SplunkEvents from 'splunk-events'
+import axios from 'axios'
+
+const splunkEvents = new SplunkEvents()
+
+splunkEvents.config({
+  endpoint: 'https://splunk-heavyforwarder-public.vtex.com:8088',
+  token: '50fe94b0-30b6-442a-9cb1-a476c97ba917',
+  request: axios,
+})
+
+interface Runtime {
+  workspace: string
+  account: string
+}
+
+interface LogConfig {
+  level: 'Critical' | 'Important' | 'Debug'
+  type: 'Error' | 'Warn' | 'Info'
+  workflowType: string
+  workflowInstance: string
+  event: any
+}
+
+declare var window: {
+  __RUNTIME__: Runtime
+}
+
+const isMasterWorkspace = () => window?.__RUNTIME__?.workspace === 'master'
+const getAccount = () => window?.__RUNTIME__?.account
+
+export const logSplunk = (config: LogConfig) => {
+  const { level, type, workflowType, workflowInstance, event } = config
+
+  if (isMasterWorkspace()) {
+    splunkEvents.logEvent(
+      level,
+      type,
+      workflowType,
+      workflowInstance,
+      event,
+      getAccount(),
+    )
+  }
+}

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -1744,6 +1744,14 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
   integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
 
+axios@^0.19.0:
+  version "0.19.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.0.tgz#8e09bff3d9122e133f7b8101c8fbdd00ed3d2ab8"
+  integrity sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==
+  dependencies:
+    follow-redirects "1.5.10"
+    is-buffer "^2.0.2"
+
 axobject-query@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-2.0.2.tgz#ea187abe5b9002b377f925d8bf7d1c561adf38f9"
@@ -2156,6 +2164,13 @@ data-urls@^1.0.0:
     abab "^2.0.0"
     whatwg-mimetype "^2.2.0"
     whatwg-url "^7.0.0"
+
+debug@=3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
+  integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
+  dependencies:
+    ms "2.0.0"
 
 debug@^2.2.0, debug@^2.3.3:
   version "2.6.9"
@@ -2742,6 +2757,13 @@ flatted@^2.0.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.1.tgz#69e57caa8f0eacbc281d2e2cb458d46fdb449e08"
   integrity sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==
 
+follow-redirects@1.5.10:
+  version "1.5.10"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.10.tgz#7b7a9f9aea2fdff36786a94ff643ed07f4ff5e2a"
+  integrity sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==
+  dependencies:
+    debug "=3.1.0"
+
 for-in@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
@@ -3152,6 +3174,11 @@ is-buffer@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
   integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
+
+is-buffer@^2.0.2:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.4.tgz#3e572f23c8411a5cfd9557c849e3665e0b290623"
+  integrity sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==
 
 is-callable@^1.1.4:
   version "1.1.4"
@@ -5280,6 +5307,11 @@ split-string@^3.0.1, split-string@^3.0.2:
   integrity sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==
   dependencies:
     extend-shallow "^3.0.0"
+
+splunk-events@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/splunk-events/-/splunk-events-1.3.0.tgz#8dbb6216c5b02a9cd920cfc9beb1fcd62a324b9d"
+  integrity sha512-1sxtP0FLJYZ3ZN2rqBo9EEFkLjR+iJjc+nB/BZNvQGgMIOGZkzuxSTMpVuYXwW/3IMhHlc/5NBjc1sYV17kkCg==
 
 sprintf-js@~1.0.2:
   version "1.0.3"


### PR DESCRIPTION
#### What problem is this solving?

When the order form query fails, the Cart was wrongly showing the dummy order form data. This PR makes `order-manager` return an empty order form instead and log the error both to console and to Splunk. Also, this PR adds an `error` property to `OrderFormContext` so consuming components can treat this case.

#### How should this be manually tested?

Go to [this workspace](https://error--checkoutio.myvtex.com/cart). Open console and verify an error was logged. Go to [Splunk](https://splunk7.vtex.com/en-US/app/vtex_checkout_ui/search?q=search%20index%3Dcheckout_ui%20account%3Dcheckoutio&display.page.search.mode=smart&dispatch.sample_ratio=1&earliest=-5m%40m&latest=now) and verify the error was logged.

#### Checklist/Reminders

- [x] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
