### PR TITLE
Remove warnings from tests

### DIFF
--- a/.github/workflows/testreact.yml
+++ b/.github/workflows/testreact.yml
@@ -1,0 +1,25 @@
+name: Test CI
+
+on:
+  pull_request:
+    branches:
+    - master
+
+jobs:
+  test-react:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Use Node.js 12.x
+      uses: actions/setup-node@v1
+      with:
+        node-version: 12.x
+    - name: Run React tests
+      run: |
+        cd react
+        yarn
+        yarn test --passWithNoTests
+      env:
+        CI: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Warnings from tests.
+
 ## [0.6.4] - 2019-12-09
 
 ### Fixed

--- a/react/package.json
+++ b/react/package.json
@@ -15,6 +15,7 @@
     "yarn": "^1.17.3"
   },
   "devDependencies": {
+    "@apollo/react-testing": "^3.1.3",
     "@types/classnames": "^2.2.7",
     "@types/graphql": "^14.2.0",
     "@types/jest": "^24.0.11",
@@ -30,9 +31,9 @@
     "eslint-config-vtex-react": "^4.1.0",
     "prettier": "^1.18.2",
     "tslint-eslint-rules": "^5.4.0",
-    "typescript": "3.5.2",
-    "vtex.checkout-resources": "http://vtex.vteximg.com.br/_v/public/typings/v1/vtex.checkout-resources@0.12.0/public/_types/react",
-    "vtex.render-runtime": "http://vtex.vteximg.com.br/_v/public/typings/v1/vtex.render-runtime@8.79.0/public/@types/vtex.render-runtime"
+    "typescript": "3.7.3",
+    "vtex.checkout-resources": "http://vtex.vteximg.com.br/_v/public/typings/v1/vtex.checkout-resources@0.13.0/public/_types/react",
+    "vtex.render-runtime": "http://vtex.vteximg.com.br/_v/public/typings/v1/vtex.render-runtime@8.82.0/public/@types/vtex.render-runtime"
   },
   "version": "0.6.4"
 }

--- a/react/utils/dummyOrderForm.ts
+++ b/react/utils/dummyOrderForm.ts
@@ -1,8 +1,8 @@
-const dummyItem = {
+const dummyItem = (id: string) => ({
   additionalInfo: {
     brandName: '',
   },
-  id: '',
+  id: id,
   detailUrl: '',
   imageUrl: '',
   listPrice: 0,
@@ -15,10 +15,10 @@ const dummyItem = {
   skuName: '',
   skuSpecifications: [],
   availability: 'available',
-}
+})
 
 export const dummyOrderForm = {
-  items: [dummyItem, dummyItem],
+  items: [dummyItem('1'), dummyItem('2')],
   shipping: {
     countries: [],
     deliveryOptions: [

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -5616,12 +5616,7 @@ type-fest@^0.5.2:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.5.2.tgz#d6ef42a0356c6cd45f49485c3b6281fc148e48a2"
   integrity sha512-DWkS49EQKVX//Tbupb9TFa19c7+MK1XmzkrZUR8TAktmE/DizXoaoJV6TZ/tSIPXipqNiRI6CyAe7x69Jb6RSw==
 
-typescript@3.5.2:
-  version "3.5.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.2.tgz#a09e1dc69bc9551cadf17dba10ee42cf55e5d56c"
-  integrity sha512-7KxJovlYhTX5RaRbUdkAXN1KUZ8PwWlTzQdHV6xNqvuFOs7+WBo10TQUqT19Q/Jz2hk5v9TQDIhyLhhJY4p5AA==
-
-typescript@^3.7.3:
+typescript@3.7.3, typescript@^3.7.3:
   version "3.7.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.3.tgz#b36840668a16458a7025b9eabfad11b66ab85c69"
   integrity sha512-Mcr/Qk7hXqFBXMN7p7Lusj1ktCBydylfQM/FZCk5glCNQJrCUKPkMHdo9R0MTFWsC/4kPFvDS0fDPvukfCkFsw==
@@ -5737,13 +5732,13 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-"vtex.checkout-resources@http://vtex.vteximg.com.br/_v/public/typings/v1/vtex.checkout-resources@0.12.0/public/_types/react":
+"vtex.checkout-resources@http://vtex.vteximg.com.br/_v/public/typings/v1/vtex.checkout-resources@0.13.0/public/_types/react":
   version "0.0.0"
-  resolved "http://vtex.vteximg.com.br/_v/public/typings/v1/vtex.checkout-resources@0.12.0/public/_types/react#fa7a0347e046eab3dd768998fc9252b2c0dd5aef"
+  resolved "http://vtex.vteximg.com.br/_v/public/typings/v1/vtex.checkout-resources@0.13.0/public/_types/react#fa7a0347e046eab3dd768998fc9252b2c0dd5aef"
 
-"vtex.render-runtime@http://vtex.vteximg.com.br/_v/public/typings/v1/vtex.render-runtime@8.79.0/public/@types/vtex.render-runtime":
-  version "8.79.0"
-  resolved "http://vtex.vteximg.com.br/_v/public/typings/v1/vtex.render-runtime@8.79.0/public/@types/vtex.render-runtime#720e67e81ed9ff32da987c5b1d3f5c77603bde70"
+"vtex.render-runtime@http://vtex.vteximg.com.br/_v/public/typings/v1/vtex.render-runtime@8.82.0/public/@types/vtex.render-runtime":
+  version "8.82.0"
+  resolved "http://vtex.vteximg.com.br/_v/public/typings/v1/vtex.render-runtime@8.82.0/public/@types/vtex.render-runtime#55c3bdec010133488255d3e679713cf3290369e4"
 
 w3c-hr-time@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
#### What problem is this solving?

Once `@vtex/test-tools` was updated to major 2 the tests started to show ugly red warnings like the ones below:

```
      Warning: An update to OrderFormProvider inside a test was not wrapped in act(...).

      When testing, code that causes React state updates should be wrapped into act(...):

      act(() => {
        /* fire events that update state */
      });
      /* assert on the output */

      This ensures that you're testing the behavior the user would see in the browser. Learn more at https://fb.me/react-wrap-tests-with-act
          in OrderFormProvider
          in ApolloProvider (created by MockedProvider)
          in MockedProvider
          in IntlProvider
```

This PR makes these warnings go away

#### How should this be manually tested?

`yarn test` should result in just this:
```
> yarn test
yarn run v1.19.2
warning package.json: No license field
$ vtex-test-tools test
 PASS  modules/TaskQueue.test.ts
 PASS  __tests__/OrderQueue.test.tsx
 PASS  __tests__/OrderForm.test.tsx

Test Suites: 3 passed, 3 total
Tests:       16 passed, 16 total
Snapshots:   0 total
Time:        2.95s
Ran all test suites.
✨  Done in 5.02s.
```
:satisfaction:

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
✔️ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
