### PR TITLE
Fix order form loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- `loading` property from the `OrderFormContext` being set to `false` before the order form was updated with the proper values.
+
 ## [0.6.6] - 2019-12-13
 
 ### Added

--- a/react/OrderForm.tsx
+++ b/react/OrderForm.tsx
@@ -4,6 +4,7 @@ import React, {
   useMemo,
   useReducer,
   useEffect,
+  useState,
   FC,
 } from 'react'
 import { ApolloError, useQuery } from 'react-apollo'
@@ -23,12 +24,11 @@ interface Context {
 const OrderFormContext = createContext<Context | undefined>(undefined)
 
 export const OrderFormProvider: FC = ({ children }) => {
-  const { loading, data, error } = useQuery<{ orderForm: OrderForm }>(
-    OrderFormQuery,
-    {
-      ssr: false,
-    }
-  )
+  const { loading: loadingQuery, data, error } = useQuery<{
+    orderForm: OrderForm
+  }>(OrderFormQuery, {
+    ssr: false,
+  })
 
   const [orderForm, setOrderForm] = useReducer(
     (orderForm: OrderForm, newOrderForm: Partial<OrderForm>) => ({
@@ -37,6 +37,8 @@ export const OrderFormProvider: FC = ({ children }) => {
     }),
     dummyOrderForm
   )
+
+  const [loading, setLoading] = useState(true)
 
   useEffect(() => {
     if (error) {
@@ -52,12 +54,13 @@ export const OrderFormProvider: FC = ({ children }) => {
       console.error(error.message)
     }
 
-    if (loading) {
+    if (loadingQuery) {
       return
     }
 
+    setLoading(false)
     data && setOrderForm(data.orderForm)
-  }, [data, error, loading])
+  }, [data, error, loadingQuery])
 
   const value = useMemo(
     () => ({


### PR DESCRIPTION
#### What problem is this solving?

When the product list is loading, it displays for a very brief moment data from a dummy order form, which is used solely as base for the loading skeleton.

The issue is a kind of a race condition on the `loading` variable set by `order-manager`. Before the changes of this PR, the `loading` variable of the context provided by `order-manager` comes directly from the `loading` value returned by the GraphQL query. This variable was used both to determine whether to display the skeleton and as a trigger to set the order form with the values returned by the query. What happened is that we were removing the skeleton before the order form was updated.

This PR fixes this problem by setting the context's `loading` property after the order form is set with the content returned by the query.

#### How should this be manually tested?

Load [this workspace](https://loading--checkoutio.myvtex.com/cart/add?sku=31&sku=33&sku=250) and watch closely the product list. It should not display weird products when transitioning from the skeleton to the actual products.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] [Linked this PR to a Clubhouse story (if applicable)](https://app.clubhouse.io/vtex/story/28315/eu-como-comprador-fico-confuso-com-informações-que-piscam-durante-o-carregamento-do-carrinho).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
