### PR TITLE
Do not use cache for orderform query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Removed
+
+- Cache from `OrderForm` query.
+
 ## [0.6.7] - 2019-12-20
 
 ### Fixed

--- a/react/OrderForm.tsx
+++ b/react/OrderForm.tsx
@@ -28,6 +28,7 @@ export const OrderFormProvider: FC = ({ children }) => {
     orderForm: OrderForm
   }>(OrderFormQuery, {
     ssr: false,
+    fetchPolicy: 'network-only',
   })
 
   const [orderForm, setOrderForm] = useReducer(


### PR DESCRIPTION
#### What problem is this solving?

This is a temporary fix to the inconsistencies observed when navigating between departments and when going to the new cart from the store page.

We currently use the `navigate` function provided by `render-runtime` to navigate between departments. We want to use the same function to navigate from the store to the new cart, because it provides a faster and smoother transition than a simple page redirect.

However, when using this function, GraphQL data is fetched from the local cache. Due to several complications, the data for the `OrderForm` query is not properly stored in the cache, resulting in inconsistencies between server and local data.

Trying to fix the cache issue has proven itself to be more complex than I initially thought, so for now this PR removes the cache for this query to unblock the development of features that rely on this component.

#### How should this be manually tested?

In [this workspace](https://nocache--checkoutio.myvtex.com/), add an item to cart, click the Minicart then click Go To Checkout. The cart page should display the item you just added.
In this [other workspace](https://nocache--storecomponents.myvtex.com/), add an item to cart then navigate to some department. The Minicart icon should display the correct number of items in the cart.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] [Linked this PR to a Clubhouse story (if applicable)](https://app.clubhouse.io/vtex/story/28464/investigar-possível-problema-de-cache-do-apollo-no-minicart).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
