### PR TITLE
Add cache to OrderForm query in Apollo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Cache to `OrderForm` query in Apollo.
+
+### Fixed
+
+- OrderForm data in Apollo's cache is now updated when the local OrderForm is modified.
+
 ## [0.6.8] - 2019-12-27
 
 ### Removed


### PR DESCRIPTION
#### What problem is this solving?

This adds back the cache to the OrderForm query. It was removed in https://github.com/vtex-apps/order-manager/pull/22 because it was causing inconsistencies in the UI. In order to resolve this issue, this PR also changes the behavior of the `setOrderForm` function of the `OrderFormContext`. It now updates the Apollo cache whenever the function is called. This ensures the UI remains consistent when navigating in the store.

#### How should this be manually tested?

In [this workspace](https://cache--checkoutio.myvtex.com/), add some items to the cart, click the Minicart then click Go To Checkout. Since data is fetched from cache, you should see the items you just added as soon as the page is loaded. In other words, the loading skeleton should not appear.
Now, click "Departamento 1". The Minicart icon should immediately display the correct number of items in cart without "blinking".

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] [Linked this PR to a Clubhouse story (if applicable)](https://app.clubhouse.io/vtex/story/28656/re-adicionar-cache-na-query-de-orderform).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
