### PR TITLE
Add id to OrderForm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `id` to OrderForm.
+
 ## [0.6.9] - 2019-12-30
 
 ### Added

--- a/react/__mocks__/mockOrderForm.ts
+++ b/react/__mocks__/mockOrderForm.ts
@@ -1,4 +1,5 @@
 export const mockOrderForm = {
+  id: '123',
   items: [
     {
       additionalInfo: {

--- a/react/typings/globals.d.ts
+++ b/react/typings/globals.d.ts
@@ -1,4 +1,5 @@
 interface OrderForm {
+  id: string
   items: Item[]
   marketingData: MarketingData | null
   totalizers: Totalizer[]

--- a/react/utils/dummyOrderForm.ts
+++ b/react/utils/dummyOrderForm.ts
@@ -18,6 +18,7 @@ const dummyItem = (id: string) => ({
 })
 
 export const dummyOrderForm = {
+  id: '',
   items: [dummyItem('1'), dummyItem('2')],
   shipping: {
     countries: [],
@@ -50,6 +51,7 @@ export const dummyOrderForm = {
 }
 
 export const emptyOrderForm = {
+  id: '',
   items: [],
   shipping: {
     countries: [],


### PR DESCRIPTION
#### What problem is this solving?

Make it possible to pass the orderForm id to pixels.

#### How should this be manually tested?

[Workspace](https://breno--storecomponents.myvtex.com/)

#### Checklist/Reminders

- [x] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] Linked this PR to a Clubhouse story (if applicable).
- [X] Updated/created tests (important for bug fixes).
- [x] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️| New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

Depends on:
1. https://github.com/vtex-apps/checkout-resources/pull/21
2. https://github.com/vtex/checkout-graphql/pull/44
