### PR TITLE
Use new entrypoint for orderform query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Use the separate `default export`s from `vtex.checkout-resources`.
 
 ## [0.7.1] - 2020-02-04
 ### Changed

--- a/react/OrderForm.tsx
+++ b/react/OrderForm.tsx
@@ -9,13 +9,11 @@ import React, {
 } from 'react'
 import { ApolloClient, ApolloError } from 'apollo-client'
 import { useQuery } from 'react-apollo'
-import { Queries } from 'vtex.checkout-resources'
+import OrderFormQuery from 'vtex.checkout-resources/QueryOrderForm'
 import { OrderForm } from 'vtex.checkout-graphql'
 
 import { dummyOrderForm, emptyOrderForm } from './utils/dummyOrderForm'
 import { logSplunk } from './utils/logger'
-
-const { orderForm: OrderFormQuery } = Queries
 
 interface Context {
   loading: boolean
@@ -45,8 +43,8 @@ export const OrderFormProvider: FC = ({ children }) => {
   })
 
   const [orderForm, setOrderForm] = useReducer(
-    (orderForm: OrderForm, newOrderForm: Partial<OrderForm>) => ({
-      ...orderForm,
+    (curOrderForm: OrderForm, newOrderForm: Partial<OrderForm>) => ({
+      ...curOrderForm,
       ...newOrderForm,
     }),
     dummyOrderForm

--- a/react/__mocks__/vtex.checkout-resources/QueryOrderForm.ts
+++ b/react/__mocks__/vtex.checkout-resources/QueryOrderForm.ts
@@ -8,4 +8,4 @@ const orderForm = gql`
   }
 `
 
-export const Queries = { orderForm }
+export default orderForm

--- a/react/__tests__/OrderForm.test.tsx
+++ b/react/__tests__/OrderForm.test.tsx
@@ -4,10 +4,8 @@ import { MockedProvider } from '@apollo/react-testing'
 import { Item } from 'vtex.checkout-graphql'
 
 import { mockOrderForm } from '../__mocks__/mockOrderForm'
-import { Queries } from '../__mocks__/vtex.checkout-resources'
+import OrderForm from '../__mocks__/vtex.checkout-resources/QueryOrderForm'
 import { OrderFormProvider, useOrderForm } from '../OrderForm'
-
-const { orderForm: OrderForm } = Queries
 
 const mockQuery = {
   request: {
@@ -69,10 +67,9 @@ describe('OrderForm', () => {
       }
       return (
         <div>
-          {orderForm &&
-            orderForm.items.map((item: Item) => (
-              <div key={item.id}>{item.name}</div>
-            ))}
+          {orderForm?.items.map((item: Item) => (
+            <div key={item.id}>{item.name}</div>
+          ))}
         </div>
       )
     }
@@ -106,10 +103,9 @@ describe('OrderForm', () => {
       return (
         <div>
           <div>
-            {orderForm &&
-              orderForm.items.map((item: Item) => (
-                <div key={item.id}>{item.name}</div>
-              ))}
+            {orderForm?.items.map((item: Item) => (
+              <div key={item.id}>{item.name}</div>
+            ))}
           </div>
           <button onClick={handleClick}>update</button>
         </div>

--- a/react/typings/vtex.checkout-resources.d.ts
+++ b/react/typings/vtex.checkout-resources.d.ts
@@ -1,0 +1,6 @@
+declare module 'vtex.checkout-resources/Query*' {
+  import { DocumentNode } from 'graphql'
+
+  const value: DocumentNode
+  export default value
+}


### PR DESCRIPTION
#### What problem is this solving?

We are avoiding importing huge `default export`s with multiple GraphQL queries/mutations because that hinders performance. This PR changes `order-manager` to use the separate `default export`s from `checkout-resources`, which exports just a single query/mutation.

#### How should this be manually tested?

`yarn test` and [this workspace](https://split--checkoutio.myvtex.com)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] [Linked this PR to a Clubhouse story (if applicable)](https://app.clubhouse.io/vtex/story/31936/mudar-orquestradores-para-usarem-os-novos-entrypoints-de-queries-e-mutations-do-checkout-resources).
- [x] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
✔️ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
