### PR TITLE
Fix local order form update when authenticated

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @vtex-apps/checkout-ui

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Order form isn't updated when `canEditData` property differs.
 
 ## [0.8.2] - 2020-03-04
 ### Removed

--- a/react/OrderForm.tsx
+++ b/react/OrderForm.tsx
@@ -13,6 +13,7 @@ import { OrderForm } from 'vtex.checkout-graphql'
 
 import { logSplunk } from './utils/logger'
 import { shouldUpdateOrderForm } from './utils/heuristics'
+import { UNSYNC_ORDER_FORM_VALUE } from './constants'
 
 type OrderFormUpdate =
   | Partial<OrderForm>
@@ -26,10 +27,6 @@ interface Context {
 }
 
 const noop = () => {}
-
-// keep default value as -1 to indicate this order form
-// is the initial value (not yet synchonized with server).
-const UNSYNC_ORDER_FORM_VALUE = -1
 
 const DEFAULT_ORDER_FORM: OrderForm = {
   id: 'default-order-form',
@@ -124,10 +121,7 @@ export const OrderFormProvider: FC = ({ children }) => {
     if (localOrderFormString != null) {
       const localOrderForm = JSON.parse(localOrderFormString) as OrderForm
 
-      if (
-        localOrderForm.value !== UNSYNC_ORDER_FORM_VALUE &&
-        !shouldUpdateOrderForm(localOrderForm, data.orderForm)
-      ) {
+      if (!shouldUpdateOrderForm(localOrderForm, data.orderForm)) {
         return
       }
     }

--- a/react/OrderForm.tsx
+++ b/react/OrderForm.tsx
@@ -12,6 +12,7 @@ import { ApolloError } from 'apollo-client'
 import { OrderForm } from 'vtex.checkout-graphql'
 
 import { logSplunk } from './utils/logger'
+import { shouldUpdateOrderForm } from './utils/heuristics'
 
 type OrderFormUpdate =
   | Partial<OrderForm>
@@ -123,7 +124,10 @@ export const OrderFormProvider: FC = ({ children }) => {
     if (localOrderFormString != null) {
       const localOrderForm = JSON.parse(localOrderFormString) as OrderForm
 
-      if (localOrderForm.value !== UNSYNC_ORDER_FORM_VALUE) {
+      if (
+        localOrderForm.value !== UNSYNC_ORDER_FORM_VALUE ||
+        !shouldUpdateOrderForm(localOrderForm, data.orderForm)
+      ) {
         return
       }
     }

--- a/react/OrderForm.tsx
+++ b/react/OrderForm.tsx
@@ -125,7 +125,7 @@ export const OrderFormProvider: FC = ({ children }) => {
       const localOrderForm = JSON.parse(localOrderFormString) as OrderForm
 
       if (
-        localOrderForm.value !== UNSYNC_ORDER_FORM_VALUE ||
+        localOrderForm.value !== UNSYNC_ORDER_FORM_VALUE &&
         !shouldUpdateOrderForm(localOrderForm, data.orderForm)
       ) {
         return

--- a/react/__mocks__/mockOrderForm.ts
+++ b/react/__mocks__/mockOrderForm.ts
@@ -64,5 +64,11 @@ export const mockOrderForm = Object.freeze({
       value: 9585000,
     },
   ],
+  clientProfileData: {
+    email: '***@vt**.**',
+    firstName: 'U*e*',
+    lastName: 'N*m*',
+  },
+  canEditData: false,
   value: 9585000,
 })

--- a/react/__mocks__/vtex.checkout-resources/QueryOrderForm.ts
+++ b/react/__mocks__/vtex.checkout-resources/QueryOrderForm.ts
@@ -5,6 +5,12 @@ const orderForm = gql`
     orderForm {
       id
       items
+      canEditData
+      clientProfileData {
+        email
+        firstName
+        lastName
+      }
       value
     }
   }

--- a/react/constants.ts
+++ b/react/constants.ts
@@ -2,3 +2,7 @@ export enum QueueStatus {
   PENDING = 'Pending',
   FULFILLED = 'Fulfilled',
 }
+
+// keep default value as -1 to indicate this order form
+// is the initial value (not yet synchonized with server).
+export const UNSYNC_ORDER_FORM_VALUE = -1

--- a/react/package.json
+++ b/react/package.json
@@ -27,7 +27,7 @@
     "eslint-config-vtex-react": "^5.1.0",
     "prettier": "^1.19.1",
     "tslint-eslint-rules": "^5.4.0",
-    "typescript": "3.7.3",
+    "typescript": "3.8.3",
     "vtex.checkout-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.22.0/public/@types/vtex.checkout-graphql",
     "vtex.checkout-resources": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-resources@0.16.0/public/@types/vtex.checkout-resources",
     "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.91.0/public/@types/vtex.render-runtime"

--- a/react/utils/heuristics.ts
+++ b/react/utils/heuristics.ts
@@ -1,0 +1,17 @@
+import { OrderForm } from 'vtex.checkout-graphql'
+
+/**
+ * Heuristic function to determine whether or not the local
+ * order form (stored in localStorage) should be replaced by
+ * the remote order form.
+ *
+ * This should only cover edge cases, as the default cases (like
+ * when there is no local order form yet) are handled by the
+ * calling function.
+ */
+export const shouldUpdateOrderForm = (
+  localOrderForm: OrderForm,
+  remoteOrderForm: OrderForm
+): boolean => {
+  return localOrderForm.canEditData !== remoteOrderForm.canEditData
+}

--- a/react/utils/heuristics.ts
+++ b/react/utils/heuristics.ts
@@ -11,9 +11,8 @@ export const shouldUpdateOrderForm = (
   localOrderForm: OrderForm,
   remoteOrderForm: OrderForm
 ): boolean => {
-  if (localOrderForm.value === UNSYNC_ORDER_FORM_VALUE) {
-    return true
-  }
-
-  return localOrderForm.canEditData !== remoteOrderForm.canEditData
+  return (
+    localOrderForm.value === UNSYNC_ORDER_FORM_VALUE ||
+    localOrderForm.canEditData !== remoteOrderForm.canEditData
+  )
 }

--- a/react/utils/heuristics.ts
+++ b/react/utils/heuristics.ts
@@ -1,17 +1,19 @@
 import { OrderForm } from 'vtex.checkout-graphql'
 
+import { UNSYNC_ORDER_FORM_VALUE } from '../constants'
+
 /**
  * Heuristic function to determine whether or not the local
  * order form (stored in localStorage) should be replaced by
  * the remote order form.
- *
- * This should only cover edge cases, as the default cases (like
- * when there is no local order form yet) are handled by the
- * calling function.
  */
 export const shouldUpdateOrderForm = (
   localOrderForm: OrderForm,
   remoteOrderForm: OrderForm
 ): boolean => {
+  if (localOrderForm.value === UNSYNC_ORDER_FORM_VALUE) {
+    return true
+  }
+
   return localOrderForm.canEditData !== remoteOrderForm.canEditData
 }

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -5958,7 +5958,12 @@ type-fest@^0.8.1:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
 
-typescript@3.7.3, typescript@^3.7.3:
+typescript@3.8.3:
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
+  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
+
+typescript@^3.7.3:
   version "3.7.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.3.tgz#b36840668a16458a7025b9eabfad11b66ab85c69"
   integrity sha512-Mcr/Qk7hXqFBXMN7p7Lusj1ktCBydylfQM/FZCk5glCNQJrCUKPkMHdo9R0MTFWsC/4kPFvDS0fDPvukfCkFsw==


### PR DESCRIPTION
#### What problem is this solving?
When you didn't login in the store, and proceeded to checkout, the orderForm could be in a state where the user couldn't edit its data (e.g.: data was autofilled by smartcheckout). So, if the user wanted to edit their data, they should login in the store, but this didn't trigger any change to the local orderForm, making the user see the masked data even though they are authenticated.

This PR adds a new function `shouldUpdateOrderForm` that should contain all heuristics so we know whether or not to replace the local orderForm with the remote one. We can start with this case where you are not logged in and the data was autofilled, and you login after it. One scenario I know is to update the orderForm when the remote and local ids differ, but we found some inconsistencies (see more in #33) due to having two `OrderFormProvider`s.

#### How should this be manually tested?
[Workspace](https://chkio--checkoutio.myvtex.com/).

Do the following:

1. First of all, delete you `checkout.vtex.com` cookie and remove the `orderform` from `localStorage`. You should also be logged out.
2. Add something to your cart and go to [checkout identification](http://chkio--checkoutio.myvtex.com/checkout/identification).
3. Enter a email that already have some data in this account.
4. Go back, and login.
5. Go to checkout again, you should be able to see and edit your data.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [x] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->