### PR TITLE
Add `setCheckoutCookie` prop to OrderFormProvider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `setOrderFormCookie` to `OrderFormProvider`.
 
 ## [0.8.2] - 2020-03-04
 ### Removed

--- a/react/OrderForm.tsx
+++ b/react/OrderForm.tsx
@@ -24,6 +24,10 @@ interface Context {
   error: ApolloError | undefined
 }
 
+interface Props {
+  setCheckoutCookie?: boolean
+}
+
 const noop = () => {}
 
 // keep default value as -1 to indicate this order form
@@ -88,11 +92,17 @@ const getLocalOrderForm = (): OrderForm | null => {
     : JSON.parse(localStorage.getItem('orderform') ?? 'null')
 }
 
-export const OrderFormProvider: FC = ({ children }) => {
+export const OrderFormProvider: FC<Props> = ({
+  children,
+  setCheckoutCookie = false,
+}) => {
   const { loading, data, error } = useQuery<{
     orderForm: OrderForm
   }>(OrderFormQuery, {
     ssr: false,
+    variables: {
+      setCheckoutCookie,
+    },
   })
 
   const [orderForm, setOrderForm] = useReducer(

--- a/react/__tests__/OrderForm.test.tsx
+++ b/react/__tests__/OrderForm.test.tsx
@@ -9,6 +9,9 @@ import { OrderFormProvider, useOrderForm } from '../OrderForm'
 const mockQuery = {
   request: {
     query: OrderForm,
+    variables: {
+      setCheckoutCookie: false,
+    },
   },
   result: {
     data: {

--- a/react/package.json
+++ b/react/package.json
@@ -27,7 +27,7 @@
     "eslint-config-vtex-react": "^5.1.0",
     "prettier": "^1.19.1",
     "tslint-eslint-rules": "^5.4.0",
-    "typescript": "3.7.3",
+    "typescript": "3.8.3",
     "vtex.checkout-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.22.0/public/@types/vtex.checkout-graphql",
     "vtex.checkout-resources": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-resources@0.16.0/public/@types/vtex.checkout-resources",
     "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.91.0/public/@types/vtex.render-runtime"

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -5958,7 +5958,12 @@ type-fest@^0.8.1:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
 
-typescript@3.7.3, typescript@^3.7.3:
+typescript@3.8.3:
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
+  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
+
+typescript@^3.7.3:
   version "3.7.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.3.tgz#b36840668a16458a7025b9eabfad11b66ab85c69"
   integrity sha512-Mcr/Qk7hXqFBXMN7p7Lusj1ktCBydylfQM/FZCk5glCNQJrCUKPkMHdo9R0MTFWsC/4kPFvDS0fDPvukfCkFsw==


### PR DESCRIPTION
#### What problem is this solving?

This should enable `OrderFormProvider` to receive a `setCheckoutCookie` which is used as a variable passed to the `orderForm` query from `checkout-graphql`.

The more detailed motivation for this change is described at [checkout-graphql](https://github.com/vtex/checkout-graphql/pull/58) and [store](https://github.com/vtex-apps/store/pull/442).

#### How should this be manually tested?

(This is the same process described at https://github.com/vtex-apps/store/pull/442)

1. Go to [this workspace](https://victorhmp--storecomponents.myvtex.com/), where there is only the new `OrderFormProvider` being used (`orderFormOptimization` is enabled), and see that the store is functioning as it should;
2. Go to [this workspace](https://victorhmp--alssports.myvtex.com/) where there are **two** `OrderFormProvider`s being used, along with the legacy `minicart` and `buy-button` blocks, instead of the new ones, which means they consume and alter the legacy `OrderFormContext`;
3. Check that adding, removing and changing the number of items in the `minicart` all work as expected.


#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

Depends on

- https://github.com/vtex/checkout-graphql/pull/58
- https://github.com/vtex-apps/checkout-resources/pull/43
