### PR TITLE
CHUI-33: Update local orderForm based on the remote value if possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Delay minicart state if user isn't offline until orderForm query completes.
 
 ## [0.8.4] - 2020-03-31
 ### Fixed

--- a/react/OrderQueue.tsx
+++ b/react/OrderQueue.tsx
@@ -3,10 +3,10 @@ import React, {
   FC,
   ReactNode,
   useContext,
-  useEffect,
   useMemo,
   useRef,
   useState,
+  useLayoutEffect,
 } from 'react'
 
 import { QueueStatus } from './constants'
@@ -33,7 +33,7 @@ const OrderQueueContext = createContext<Context | undefined>(undefined)
 export const useQueueStatus = (listen: ListenFunction) => {
   const queueStatus = useRef(QueueStatus.FULFILLED)
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     const unlisten = listen(
       QueueStatus.PENDING,
       () => (queueStatus.current = QueueStatus.PENDING)
@@ -41,7 +41,7 @@ export const useQueueStatus = (listen: ListenFunction) => {
     return unlisten
   }, [listen])
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     const unlisten = listen(
       QueueStatus.FULFILLED,
       () => (queueStatus.current = QueueStatus.FULFILLED)

--- a/react/__tests__/OrderForm.test.tsx
+++ b/react/__tests__/OrderForm.test.tsx
@@ -5,6 +5,7 @@ import OrderForm from 'vtex.checkout-resources/QueryOrderForm'
 
 import { mockOrderForm } from '../__fixtures__/orderForm'
 import { OrderFormProvider, useOrderForm } from '../OrderForm'
+import { OrderQueueProvider } from '../OrderQueue'
 
 const mockQuery = {
   request: {
@@ -46,9 +47,11 @@ describe('OrderForm', () => {
     }
 
     const { getByText } = render(
-      <OrderFormProvider>
-        <Component />
-      </OrderFormProvider>,
+      <OrderQueueProvider>
+        <OrderFormProvider>
+          <Component />
+        </OrderFormProvider>
+      </OrderQueueProvider>,
       { graphql: { mocks: [mockQuery] } }
     )
 
@@ -85,9 +88,11 @@ describe('OrderForm', () => {
     }
 
     const { getByText } = render(
-      <OrderFormProvider>
-        <Component />
-      </OrderFormProvider>,
+      <OrderQueueProvider>
+        <OrderFormProvider>
+          <Component />
+        </OrderFormProvider>
+      </OrderQueueProvider>,
       { graphql: { mocks: [mockQuery] } }
     )
 
@@ -110,9 +115,11 @@ describe('OrderForm', () => {
     }
 
     const { getByText } = render(
-      <OrderFormProvider>
-        <Component />
-      </OrderFormProvider>,
+      <OrderQueueProvider>
+        <OrderFormProvider>
+          <Component />
+        </OrderFormProvider>
+      </OrderQueueProvider>,
       { graphql: { mocks: [mockQuery] } }
     )
 
@@ -148,9 +155,11 @@ describe('OrderForm', () => {
     }
 
     const { getByText } = render(
-      <OrderFormProvider>
-        <Component />
-      </OrderFormProvider>,
+      <OrderQueueProvider>
+        <OrderFormProvider>
+          <Component />
+        </OrderFormProvider>
+      </OrderQueueProvider>,
       { graphql: { mocks: [mockQuery] } }
     )
 
@@ -198,9 +207,11 @@ describe('OrderForm', () => {
       // we're testing the side effect, so we won't need
       // to query the document
       render(
-        <OrderFormProvider>
-          <Component />
-        </OrderFormProvider>,
+        <OrderQueueProvider>
+          <OrderFormProvider>
+            <Component />
+          </OrderFormProvider>
+        </OrderQueueProvider>,
         { graphql: { mocks: [orderFormMockQuery] } }
       )
 
@@ -250,9 +261,11 @@ describe('OrderForm', () => {
       // we're testing the side effect, so we won't need
       // to query the document
       render(
-        <OrderFormProvider>
-          <Component />
-        </OrderFormProvider>,
+        <OrderQueueProvider>
+          <OrderFormProvider>
+            <Component />
+          </OrderFormProvider>
+        </OrderQueueProvider>,
         { graphql: { mocks: [orderFormMockQuery] } }
       )
 


### PR DESCRIPTION
#### What problem is this solving?

This PR fixes an issue where the orderForm would be loaded almost exclusively from the `localStorage`, which caused some bugs where if you edited the items in the legacy Cart and went back to the store it wouldn't be updated to reflect the changes you did. It also had a few issues by displaying an old orderForm which was in an invalid state (e.g. when you finished a purchase, the minicart would show all the items you just purchased instead of a blank cart).

#### How should this be manually tested?

There is 3 workspaces you should checkout to assure this won't break existing stores: [storecomponents](https://lucas--storecomponents.myvtex.com/blouse-with-knot/p?skuId=310124165) which uses the legacy cart, [GoCommerce QAStore](https://lucas--qastore.mygocommerce.com/produtocypress/p) and [checkoutio](https://staleof--checkoutio.myvtex.com/teste-so-delivery-copy-256--copy-257--copy-261--copy-262-/p).

The recommended tests are:

 - On GC qastore you should run the [healthcheck test suite](https://github.com/vtex-gocommerce/HealthCheck-QAStore).

- On checkoutio:
  1. Access the [workspace](https://staleof--checkoutio.myvtex.com/teste-so-delivery-copy-256--copy-257--copy-261--copy-262-/p).
  2. Enable offline mode in your browser ("Work Offline" for Firefox, or set "offline" in the network panel in Chrome).
  3. Add the product to your cart.
  4. Close the tab and disable the offline mode.
  5. Enter the workspace again, you **should not** see the number of items in the minicart change while the page is loading (after JS has loaded).

- On storecomponents:
  1. Access the [workspace](https://lucas--storecomponents.myvtex.com/blouse-with-knot/p?skuId=310124165).
  2. Add the product to your cart.
  3. Go to checkout and remove the item.
  4. Go back to the store.
  5. You **should not** see the item you deleted in your minicart and the number of items should not change while the page is loading (same as for checkoutio).

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] Linked this PR to a Jira story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->