### PR TITLE
Fix stale orderForm when auth state changed

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,7 +10,7 @@
 
 - [ ] Updated `README.md`.
 - [ ] Updated `CHANGELOG.md`.
-- [ ] Linked this PR to a Clubhouse story (if applicable).
+- [ ] Linked this PR to a Jira story (if applicable).
 - [ ] Updated/created tests (important for bug fixes).
 - [ ] Deleted the workspace after merging this PR (if applicable).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Order form updated to stale data if authentication state changed (checked via `orderForm.canEditData`).
 
 ## [0.8.5] - 2020-06-17
 ### Changed

--- a/react/utils/heuristics.ts
+++ b/react/utils/heuristics.ts
@@ -17,7 +17,6 @@ export const shouldUpdateOrderForm = (
 ): boolean => {
   return (
     localOrderForm.value === UNSYNC_ORDER_FORM_VALUE ||
-    localOrderForm.canEditData !== remoteOrderForm.canEditData ||
     (orderFormOptimizationEnabled &&
       localOrderForm.id !== remoteOrderForm.id &&
       localOrderForm.id !== DEFAULT_ORDER_FORM.id)


### PR DESCRIPTION
#### What problem is this solving?

This PR fixes an issue where if you changed the authentication state in the orderForm, we would end up using the remote value returned by Apollo's `useQuery` (which after identifying, is stale). This happened because of a fix that replaced the local orderForm with the remote if the `canEditData` property changed, and in the time this was implemented we had another approach to managing both the remote and local state of the orderForm, which relied more in the local state than in the remote one.

But now we have changed how we deal with it to always fetch the remote orderForm if it is possible and wait for the query to resolve, instead of "fallbacking" to the local value, and this guarantees that we will always see the most up to date value of the orderForm, regardless of these heuristics.

#### How should this be manually tested?

[Workspace](https://lucas--checkoutio.myvtex.com/cart/add?sku=289).

To test you must access the above workspace, go to checkout and identify with a second purchase email, and then click the "Edit cart" button in the checkout page which will take you back to the cart page. You should still remaing identified (you can check by seeing if the shipping options are filled with a masked postal code).

You can also use the test plan of the PR #37 that had the fix I commented earlier.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Jira story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->