### PR TITLE
CHK-486: Add no-cache fetch policy to orderForm query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Update fetch policy on orderForm query to `no-cache`.
 
 ## [0.8.8] - 2020-11-24
 ### Changed

--- a/react/OrderForm.tsx
+++ b/react/OrderForm.tsx
@@ -81,6 +81,7 @@ export const OrderFormProvider: FC = ({ children }) => {
     orderForm: OrderForm
   }>(OrderFormQuery, {
     ssr: false,
+    fetchPolicy: 'no-cache',
   })
 
   const shouldUseLocalOrderForm =


### PR DESCRIPTION
#### What problem is this solving?

This PR makes the orderForm query skip Apollo's cache, in order to avoid an issue when the cache hints for the orderForm query aren't available, which resulted in the orderForm query result (passed through apollo's cache) to be empty (an object with only the `__typename`).

You can see more information about this bug in the [Jira issue](https://vtex-dev.atlassian.net/browse/CHK-486).

#### How should this be manually tested?

[Workspace](https://fix486--checkoutio.myvtex.com)

To assess this is working, add one product to your cart in the workspace above and reload the page. After the page has been loaded, the minicart should display the item you added.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] Linked this PR to a Jira story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

Here is some of the "evidence" as to why I think this is related to Apollo's cache:

![image](https://user-images.githubusercontent.com/10223856/101031296-54246e80-3558-11eb-8eb8-6347c3af67c1.png)

![image](https://user-images.githubusercontent.com/10223856/101031337-5686c880-3558-11eb-83df-1e2aee62dd05.png)

The first screenshot is on a breakpoint inside Apollo's [`QueryManager#fetchRequest`](https://github.com/apollographql/apollo-client/blob/release-2.x/packages/apollo-client/src/core/QueryManager.ts#L1221-L1237) method which shows that the network response correctly returned the orderForm object as we ought to receive it in `OrderFormProvider`.

The second screenshot, however, is from the [`QueryManager#broadcastQueries`](https://github.com/apollographql/apollo-client/blob/release-2.x/packages/apollo-client/src/core/QueryManager.ts#L1091) method, **which reads the query result from cache** (depending on the query `fetchPolicy`). So, somewhere in between the `fetchRequest` call and the `broadcastQueries` the result from the network response has been trimmed down to the `__typename` only, and after changing the fetch policy to `no-cache` (which makes Apollo skip saving the query result into the cache altogether and pass the network response directly) we receive the response value as usual, which is what led me to believe the issue is in how Apollo's cache is behaving with the lack of the cacheHints on this query.

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->
